### PR TITLE
Make a few more strings translatable

### DIFF
--- a/Translations/KeePassOTP.nl.language.xml
+++ b/Translations/KeePassOTP.nl.language.xml
@@ -83,7 +83,7 @@
   </item>
   <item>
     <key>TimeCorrection</key>
-    <value>Tijdcorrectie (uitsluitend TOTP & Steam)</value>
+    <value>Tijdcorrectie (uitsluitend TOTP &amp;&amp; Steam)</value>
   </item>
   <item>
     <key>URL</key>

--- a/Translations/KeePassOTP.nl.language.xml
+++ b/Translations/KeePassOTP.nl.language.xml
@@ -340,4 +340,16 @@ Dit bericht zal maar één keer getoond worden.</value>
     <key>LocalHotkeyTooltip</key>
     <value>Deze sneltoets werkt alleen binnen KeePass en zal in plaats van auto-typen de OTP waarde kopiëren naar het klembord.</value>
   </item>
+  <item>
+    <key>CurrentOTP</key>
+    <value>OTP:</value>
+  </item>
+  <item>
+    <key>NextOTP</key>
+    <value>Volgende:</value>
+  </item>
+  <item>
+    <key>NotAvailable</key>
+    <value>N.v.t.</value>
+  </item>
 </Translation>

--- a/Translations/KeePassOTP.nl.language.xml
+++ b/Translations/KeePassOTP.nl.language.xml
@@ -318,7 +318,7 @@ Dit bericht zal maar één keer getoond worden.</value>
   </item>
   <item>
     <key>OTPDisplayMode_label</key>
-    <value>Tekst KTOTP-kolom:</value>
+    <value>Tekst KPOTP-kolom:</value>
   </item>
   <item>
     <key>RecoveryCodes</key>

--- a/Translations/KeePassOTP.template.language.xml
+++ b/Translations/KeePassOTP.template.language.xml
@@ -343,4 +343,16 @@ This message will not be shown again.</value>
     <key>LocalHotkeyTooltip</key>
     <value>The hotkey will work only within KeePass and instead of Auto-Type it will copy the OTP value into the clipboard</value>
   </item>
+  <item>
+    <key>CurrentOTP</key>
+    <value>OTP:</value>
+  </item>
+  <item>
+    <key>NextOTP</key>
+    <value>Next:</value>
+  </item>
+  <item>
+    <key>NotAvailable</key>
+    <value>N/A</value>
+  </item>
 </Translation>

--- a/Translations/KeePassOTP.template.language.xml
+++ b/Translations/KeePassOTP.template.language.xml
@@ -83,7 +83,7 @@
   </item>
   <item>
     <key>TimeCorrection</key>
-    <value>Time correction - not applicable for HOTP</value>
+    <value>Time correction - TOTP &amp;&amp; Steam only</value>
   </item>
   <item>
     <key>URL</key>

--- a/src/KeePassOTPSetup.Designer.cs
+++ b/src/KeePassOTPSetup.Designer.cs
@@ -275,6 +275,7 @@ namespace KeePassOTP
             this.label1.Size = new System.Drawing.Size(60, 31);
             this.label1.TabIndex = 414;
             this.label1.Text = "N/A";
+            this.label1.UseMnemonic = false;
             this.label1.MouseHover += new System.EventHandler(this.pbQR_MouseHover);
             // 
             // tpRecovery

--- a/src/KeePassOTPSetup.cs
+++ b/src/KeePassOTPSetup.cs
@@ -242,7 +242,7 @@ namespace KeePassOTP
 			totpTimeCorrectionValue.Text = OTP.OTPTimeCorrection.ToString();
 
 			string otpValue = OTP.Valid ? OTP.ReadableOTP(OTP.GetOTP(false, true)) : PluginTranslate.Error;
-			otpPreview.Text = "OTP: " + (string.IsNullOrEmpty(otpValue) ? "N/A" : otpValue);
+			otpPreview.Text = PluginTranslate.CurrentOTP.ToString() + " " + (string.IsNullOrEmpty(otpValue) ? PluginTranslate.NotAvailable.ToString() : otpValue);
 			if ((OTP.Type != KPOTPType.HOTP) && OTP.RemainingSeconds <= Config.TOTPSoonExpiring)
 			{
 				otpPreview.ForeColor = System.Drawing.Color.Red;
@@ -257,7 +257,7 @@ namespace KeePassOTP
 			OTP.RecoveryCodes = GetRecoveryCodes();
 
 			otpValue = OTP.Valid ? OTP.ReadableOTP(OTP.GetOTP(true, true)) : PluginTranslate.Error;
-			otpPreviewNext.Text = "Next: " + (string.IsNullOrEmpty(otpValue) ? "N/A" : otpValue);
+			otpPreviewNext.Text = PluginTranslate.NextOTP.ToString() + " " + (string.IsNullOrEmpty(otpValue) ? PluginTranslate.NotAvailable.ToString() : otpValue);
 		}
 
         private void GetOTPSettingsInt(out int iFormat, out int iLength, out string sTimestep, out int iHash, out int iType)

--- a/src/PluginTranslation.cs
+++ b/src/PluginTranslation.cs
@@ -413,6 +413,18 @@ This message will not be shown again.";
 		/// The hotkey will work only within KeePass and instead of Auto-Type it will copy the OTP value into the clipboard
 		/// </summary>
 		public static readonly string LocalHotkeyTooltip = @"The hotkey will work only within KeePass and instead of Auto-Type it will copy the OTP value into the clipboard";
+		/// <summary>
+		/// Next
+		/// </summary>
+		public static readonly string CurrentOTP = @"OTP:";
+		/// <summary>
+		/// Next
+		/// </summary>
+		public static readonly string NextOTP = @"Next:";
+		/// <summary>
+		/// N/A
+		/// </summary>
+		public static readonly string NotAvailable = @"N/A";
 		#endregion
 
 		#region NO changes in this area


### PR DESCRIPTION
For the Dutch translation I would like to translate a few more strings, 'Next' and 'N/A' in the seed part of the setup dialog.

Another word that may be better to have a separate translation is 'Help' in that dialog. In Dutch it is now using 'help' as in 'asking for help', instead of 'hulp' as in 'providing assistance'. But I didn't touch that one yet, and it feels minor.

The ampersand in the Drag & Drop label wasn't visible in English or Dutch, and this escaping can be turned off with the `UseMnemonic` variable.

Also fixed my two typo's in the Dutch translation, sorry.